### PR TITLE
ci: fix nonexistent actions/upload-artifact SHA pin (Refs standards#48)

### DIFF
--- a/civic-stream/.github/workflows/hypatia-scan.yml
+++ b/civic-stream/.github/workflows/hypatia-scan.yml
@@ -75,7 +75,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json

--- a/indieweb2-bastion/.github/workflows/hypatia-scan.yml
+++ b/indieweb2-bastion/.github/workflows/hypatia-scan.yml
@@ -75,7 +75,7 @@ jobs:
           echo "- Medium: $MEDIUM" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload findings artifact
-        uses: actions/upload-artifact@65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: hypatia-findings
           path: hypatia-findings.json


### PR DESCRIPTION
Bulk remediation for hyperpolymath/standards#48.

`actions/upload-artifact` was pinned to `65c79d7f54e76e4e3c7a8f34db0f4ac8b515c478` which **does not exist** in `actions/upload-artifact`, breaking every affected workflow at *Set up job*. Replaced with the real **v4.6.2** SHA `ea165f8d65b6e75b540449e92b4886f43607fa02` (the pin already used by the canonical rsr-template-repo / v3-templater generators).

SHA-only replacement; pre-existing version comments left intact (cosmetic).

Refs hyperpolymath/standards#48 — per standards#66 protocol this PR uses `Refs` (not `Closes`); joint-close only on explicit agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)