### PR TITLE
docs: seed CHANGELOG.md (Keep-a-Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
+-->
+
+# Changelog
+
+All notable changes to `civic-connect` will be documented in this file.
+
+This file is generated from conventional commits by the
+[`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml)
+workflow (`hyperpolymath/standards#206`). Adopt the workflow in this repo's CI to keep this file in sync automatically — see
+[`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml)
+for the canonical config.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- feat(crg): add crg-grade and crg-badge justfile recipes
+- feat: wire conflow config validation pipeline
+- feat: add k9iser.toml and generate K9 contracts
+- feat: add stapeln.toml container definition
+- feat: deploy UX Manifesto infrastructure
+- feat: add Groove discovery manifest
+- feat: add voice-groove service
+- feat: add CLADE.a2ml — clade taxonomy declaration
+
+### Fixed
+
+- fix(ci): bump a2ml/k9-validate-action pins to canonical (#40)
+- fix(ci): sync hypatia-scan.yml to canonical (#39)
+- fix(ci): build Hypatia escript from repo root (estate dogfood drift)
+- fix(ci): adopt canonical hypatia-scan.yml (#37)
+- fix(ci): Phase-2 fleet submission must not fail the security gate (#36)
+- fix(ci): hypatia-scan workdir (${{ env.HOME }} resolves empty) (#35)
+- fix(ci): hypatia-scan.yml -- --exit-zero + GITHUB_TOKEN (hyperpolymath/hypatia#213) (#29)
+- fix(ci): rsr-antipattern duplicate heredoc + setup-beam ubuntu24 (#31)
+- fix(ci): repair YAML block-scalar in workflow-linter Check Permissions step (#32)
+- fix(ci): move secret-scanner Cargo.toml gate from job-level if: to step-level (#33)
+
+### Changed
+
+- refactor(abi): eliminate believe_me in Layout.idr
+- refactor: migrate 6SCM → 6A2 (.scm → .a2ml format)
+
+### Documentation
+
+- docs: substantive CRG C annotation (EXPLAINME.adoc)
+- docs: add EXPLAINME.adoc — prove-it file backing README claims
+
+### CI
+
+- ci: redistribute concurrency-cancel guard to read-only check workflows (#42)
+- ci: fix nonexistent actions/upload-artifact SHA pin (Refs standards#48) (#38)
+- ci(secret-scanner): drop duplicate --fail from trufflehog extra_args (#30)
+- ci: bump actions/upload-artifact SHA to current v4 (#28)
+- ci: SHA-pin hyperpolymath validate-actions in dogfood-gate
+
+## Pre-history
+
+Prior commits to this file's introduction are recorded in git history but not formally classified into Keep-a-Changelog sections. To backfill, run `git cliff -o CHANGELOG.md` locally using the canonical [`cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml) — this is one-shot mechanical work.
+
+---
+
+<!-- This file was seeded by the 2026-05-26 estate tech-debt audit follow-up (Row-2 Phase 3); see [`hyperpolymath/standards/docs/audits/2026-05-26-estate-documentation-debt.md`](https://github.com/hyperpolymath/standards/blob/main/docs/audits/2026-05-26-estate-documentation-debt.md). -->


### PR DESCRIPTION
## Summary
Adds an initial `CHANGELOG.md` in Keep-a-Changelog format. Recent commits are bucketed into Added/Fixed/Changed/Documentation/CI from their conventional-commit prefixes.

Closes **Row-2 Phase 3** of the 2026-05-26 estate tech-debt audit chain for this repo. The audit ([standards#197](https://github.com/hyperpolymath/standards/pull/197)) flagged 180/279 repos missing CHANGELOG (65% gap).

## Adopting auto-regeneration
For ongoing auto-regeneration, adopt the [`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml) workflow ([standards#206](https://github.com/hyperpolymath/standards/pull/206)) in this repo's CI. Uses the canonical [`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)