### PR TITLE
ci(scorecard-enforcer): split score-threshold from publish job (OSSF run-step ban)

### DIFF
--- a/.github/workflows/scorecard-enforcer.yml
+++ b/.github/workflows/scorecard-enforcer.yml
@@ -21,6 +21,16 @@ permissions:
   contents: read
 
 jobs:
+  # The OSSF Scorecard publish endpoint enforces a hard contract: the job that
+  # runs `ossf/scorecard-action` with `publish_results: true` must contain
+  # ONLY steps with `uses:` (no `run:` steps in the same job). If a `run:`
+  # step is present, the publish step fails with:
+  #   "webapp: scorecard job must only have steps with uses"
+  # (49 estate repos hit this; see ROADMAP audit 2026-05-30.)
+  #
+  # Fix: split the threshold check into a downstream job that depends on
+  # `scorecard` and consumes the SARIF artifact. The `scorecard` job stays
+  # uses-only; `check-score` is the gating job that emits the error.
   scorecard:
     runs-on: ubuntu-latest
     permissions:
@@ -43,9 +53,26 @@ jobs:
         with:
           sarif_file: results.sarif
 
+      - name: Persist SARIF for downstream score-gate job
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 1
+
+  check-score:
+    needs: scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download SARIF from scorecard job
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v5.0.0
+        with:
+          name: scorecard-results
+
       - name: Check minimum score
         run: |
-          # Parse score from results
           SCORE=$(jq -r '.runs[0].tool.driver.properties.score // 0' results.sarif 2>/dev/null || echo "0")
 
           echo "OpenSSF Scorecard Score: $SCORE"


### PR DESCRIPTION
## Summary

This repo's `scorecard-enforcer.yml` has the OSSF publish-contract violation that hyperpolymath/standards#304 fixed in the canonical template. Every Scorecard run fails with:

```
webapp: scorecard job must only have steps with uses
```

## Root cause

OSSF's publish endpoint enforces a hard contract: the job that runs `ossf/scorecard-action` with `publish_results: true` must contain ONLY `uses:` steps. The pre-fix template's "Check minimum score" `run:` step in the same job fails the publish step and the whole workflow run.

## Fix

Replace local file with the post-#304 standards template:
- `scorecard` job: uses-only (now includes `upload-artifact` for SARIF hand-off)
- `check-score` job: `needs: scorecard`, downloads artifact, runs the threshold gate

## Detection going forward

Hypatia rule WF014 in hyperpolymath/hypatia#393 catches this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)