### PR TITLE
docs(readme): flip stale PMPL-1.0 license badge to MPL-2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 Privacy-first civic engagement platform with government API integration, post-quantum secure DNS, and provenance-grade audit infrastructure.
 
 image:https://img.shields.io/badge/RSR-Certified-gold[RSR Certified,link=https://github.com/hyperpolymath/rhodium-standard-repositories]
-image:https://img.shields.io/badge/License-PMPL--1.0-blue.svg[License: PMPL-1.0,link="https://github.com/hyperpolymath/palimpsest-license"]
+image:https://img.shields.io/badge/License-MPL--2.0-blue.svg[License: MPL-2.0,link="https://www.mozilla.org/MPL/2.0/"]
 
 toc::[]
 


### PR DESCRIPTION
Single-line README badge polish. Per 2026-06-02 estate license policy.