### PR TITLE
security(deps): bump rustls-webpki->0.103.13 (GHSA-82j2-j2ch-gfr8, HIGH)

### DIFF
--- a/indieweb2-bastion/graphql-dns-api/Cargo.lock
+++ b/indieweb2-bastion/graphql-dns-api/Cargo.lock
@@ -5487,7 +5487,7 @@ dependencies = [
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.11",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -5523,9 +5523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",


### PR DESCRIPTION
## What

Lockfile-only bump of `rustls-webpki` from `0.103.11` -> `0.103.13` in `indieweb2-bastion/graphql-dns-api/Cargo.lock`. No `Cargo.toml`, licence/SPDX, or `.gitattributes` files were touched. No parent crate was force-bumped across a major/breaking boundary.

## Why

Resolves **GHSA-82j2-j2ch-gfr8** (== **RUSTSEC-2026-0104**), a denial-of-service in `rustls-webpki` triggered via a malformed CRL BIT STRING. **CVSS 7.5 (HIGH)**. Vulnerable: `< 0.103.13`; fixed in `0.103.13`.

This addresses the repo's open Dependabot **high-severity** alert for `rustls-webpki`. Dependabot did **not** auto-open a PR because `rustls-webpki` is a **transitive / lockfile-only** dependency here (no direct entry in `Cargo.toml`), so the fix is applied directly to `Cargo.lock` via `cargo update -p rustls-webpki@0.103.11 --precise 0.103.13`.

## Residual (needs manual follow-up)

A second, older copy **`rustls-webpki 0.101.7` remains** and is still within the advisory's vulnerable range (`< 0.103.13`). It is pinned transitively by **`rustls 0.21.12`**, which is itself required by `hickory-proto/resolver/server v0.24.4`, `reqwest v0.11.27` (via `ethers v2.0.14`), `tokio-rustls v0.24.1`, and `tungstenite v0.20.1`. The `rustls 0.21.x` line only accepts `rustls-webpki 0.101.x`, and `0.101.7` is already the newest in that line. Lifting this copy would require a **breaking major bump of `rustls` (0.21 -> 0.23)** and its parent crates (hickory-*, reqwest 0.11 -> 0.12, ethers), which cannot be done lockfile-only and would require `Cargo.toml` edits. Per the lockfile-only / no-breaking-bump constraints, it has been **left in place** and **needs a manual parent-crate upgrade** to fully remediate.

## Provenance

- Commit is **SSH-signed** with `id_ed25519_signing` (`SHA256:kVP7Nb+Js58NvZPglm0gByBC9KeYLl/tqWpHkNN9gUA`).
- Branch was cut from a **fresh clone of `origin/main`** (no local-clone divergence).
- Only `Cargo.lock` is changed.

**Security PR -> manual review, do not auto-merge.**

Generated with Claude Code.